### PR TITLE
Fix infinite scroll issues by updating query settings

### DIFF
--- a/src/app/admin/inventory/page.tsx
+++ b/src/app/admin/inventory/page.tsx
@@ -7,6 +7,7 @@ import { AlertCircle, Edit2, Eye, Filter, Folder, LayoutGrid, Loader2, Package, 
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 
 interface MappedProduct {
     id: string;
@@ -27,6 +28,7 @@ interface MappedProduct {
 const InventoryPage = () => {
     const searchParams = useSearchParams();
     const toast = useToast();
+    const queryClient = useQueryClient();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const [products, setProducts] = useState<any[]>([]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -262,6 +264,12 @@ const InventoryPage = () => {
                 setNextCursor(null);
                 setHasMore(true);
                 fetchInventoryData();
+
+                // Storefront's InfiniteFeed reads through React Query, which this
+                // admin page never touches otherwise — without this, a storefront
+                // tab open in the same session keeps showing the deleted product.
+                queryClient.invalidateQueries({ queryKey: ["infinite-products"] });
+                queryClient.invalidateQueries({ queryKey: ["category-products"] });
             } catch (error) {
                 console.error('Error deleting product:', error);
                 // Show error toast

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,7 +35,6 @@ const EMPTY_PRODUCTS: Product[] = Object.freeze([]) as unknown as Product[];
 
 const productQueryFn = async (cursor: string) => {
   const res = await getProducts(`limit=${ITEMS_TO_APPEND}&cursor=${cursor}`);
-  console.log(res?.message.products);
   return {
     items: res?.message?.products ?? EMPTY_PRODUCTS,
     nextCursor: res?.message?.nextCursor ?? null,
@@ -273,7 +272,6 @@ function HomeContent({ heroProducts, isHeroLoading }: HomeContentProps) {
                 <EndlessScrollLoading infiniteRef={ref} hasNextPage={true} />
               )}
               shuffle={shuffleArray}
-              staleTime={Infinity}
               scrollRestorationKey="home-scroll-y"
               gridClassName="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-x-2 lg:gap-6"
               className="mt-8"

--- a/src/app/provider.tsx
+++ b/src/app/provider.tsx
@@ -1,17 +1,28 @@
 "use client";
 
-import { GoogleOAuthProvider } from "@react-oauth/google";
+import { getBearerToken } from "@/lib/api";
 import { useCartStore } from "@/lib/stores/cart-store";
 import { useWishlistStore } from "@/lib/stores/wishlist-store";
+import { GoogleOAuthProvider } from "@react-oauth/google";
+import { createSyncStoragePersister } from "@tanstack/query-sync-storage-persister";
 import { QueryClient } from "@tanstack/react-query";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
-import { createSyncStoragePersister } from "@tanstack/query-sync-storage-persister";
-import { useState, useEffect } from "react";
-import { getBearerToken } from "@/lib/api";
+import { useEffect, useState } from "react";
 
 const GOOGLE_CLIENT_ID =
   process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ??
   "97080942381-seubabjh0nq15hdv2nhgj0ij4vjafoh5.apps.googleusercontent.com";
+
+// Query keys that are safe to restore from localStorage on page load — low
+// volatility, not affected by admin CRUD actions taken in another tab/device.
+// Everything else (products, search, feeds) must always be fetched fresh, since
+// an admin deleting a product elsewhere has no way to reach into a customer's
+// localStorage to invalidate a persisted snapshot.
+const PERSISTABLE_QUERY_KEYS = new Set(["categories", "home-banner"]);
+
+// Bump this string whenever the shape of a persisted query changes (or on a
+// deploy where you want to force everyone's persisted cache to drop).
+const PERSIST_BUSTER = "v1";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -70,7 +81,16 @@ export function Providers({ children }: { children: React.ReactNode }) {
     <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>
       <PersistQueryClientProvider
         client={queryClient}
-        persistOptions={{ persister }}
+        persistOptions={{
+          persister,
+          buster: PERSIST_BUSTER,
+          maxAge: 1000 * 60 * 60 * 12, // 12h — persisted snapshots older than this are discarded outright
+          dehydrateOptions: {
+            shouldDehydrateQuery: (query) =>
+              query.state.status === "success" &&
+              PERSISTABLE_QUERY_KEYS.has(query.queryKey[0] as string),
+          },
+        }}
       >
         {children}
       </PersistQueryClientProvider>

--- a/src/components/InfinteScrollList.tsx
+++ b/src/components/InfinteScrollList.tsx
@@ -105,7 +105,7 @@ interface SlottedItem<T> {
 export function InfiniteFeed<T>({
   queryKey,
   queryFn,
-  staleTime = Infinity,
+  staleTime = 0,
   renderItem,
   getItemId,
   emptyComponent,
@@ -127,6 +127,7 @@ export function InfiniteFeed<T>({
   // ── Infinite Query ───────────────────────────────────────────────────────────
   const {
     data,
+    dataUpdatedAt,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
@@ -146,6 +147,7 @@ export function InfiniteFeed<T>({
     () => data?.pages.flatMap((p) => p.items) ?? [],
     [data?.pages]
   );
+
 
   const isRecycleMode = !hasNextPage && sourceItems.length > 0;
 
@@ -168,6 +170,21 @@ export function InfiniteFeed<T>({
 
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   const apiLoadMoreRef = useRef<HTMLDivElement | null>(null);
+
+  // ── Reseed on fresh data ───────────────────────────────────────────────────────
+  // A completed refetch (e.g. the automatic staleTime:0 mount refetch, or a
+  // pull-to-refresh) replaces `data`, but once recycle mode has already seeded
+  // once it otherwise never looks at `data` again — so a product deleted after
+  // seeding would stay visible forever. Un-seed whenever the query resolves with
+  // a newer `dataUpdatedAt`, which lets the seed effect below rebuild the
+  // recycle pool from the fresh source items.
+  const seededAtRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!isRecycleMode) return;
+    if (seededAtRef.current === dataUpdatedAt) return;
+    seededAtRef.current = dataUpdatedAt;
+    setIsSeeded(false);
+  }, [isRecycleMode, dataUpdatedAt]);
 
   // ── Seed ─────────────────────────────────────────────────────────────────────
   // Fires once when the API has no more pages.


### PR DESCRIPTION
Resolve infinite scroll problems by adjusting query invalidation and stale time settings. This ensures that deleted products do not persist in the view when using the infinite scroll feature.